### PR TITLE
Updates for 0.16

### DIFF
--- a/Css/Example/Example3.elm
+++ b/Css/Example/Example3.elm
@@ -78,8 +78,8 @@ flex styles =
 
 responsiveRow : Int -> Styles -> Styles
 responsiveRow width styles =
-  if | width < medium -> column <| flex styles
-     | otherwise -> flex styles
+  if width < medium column <| flex styles
+     else flex styles
 
 
 end : Styles -> Styles
@@ -176,8 +176,8 @@ flex styles =
 
 responsiveRow : Int -> Styles -> Styles
 responsiveRow width styles =
-  if | width < medium -> column <| flex styles
-     | otherwise -> flex styles
+  if width < medium then column <| flex styles
+  else flex styles
 
 
 end : Styles -> Styles

--- a/Css/Flex.elm
+++ b/Css/Flex.elm
@@ -413,7 +413,7 @@ justifyContent j styles =
         else style name "space-around" styles
 
 
-{-else if Set how the flex items are laid out along the
+{-| else if Set how the flex items are laid out along the
 cross axis on the current line. Think of it as the justifyContent version
 for the cross axis (perpendicular to the main axis).
 
@@ -455,7 +455,7 @@ alignItems a styles =
         else style "align-items" (alignItemString a) styles
 
 
-{-else if Set how to align the flex container's lines within when
+{-| else if Set how to align the flex container's lines within when
 there is extra space in the cross axis.
 
     import Css.Flex as Flex
@@ -515,7 +515,7 @@ alignContent a styles =
         else style name (alignContentString a) styles
 
 
-{-else if Set the order in which items appear in the flex container.
+{-| else if Set the order in which items appear in the flex container.
 
     import Css.Flex as Flex
 
@@ -536,7 +536,7 @@ order o styles =
     else style name (toString o) styles
 
 
-{-else if Set the ability for a flex item to grow if necessary.
+{-| else if Set the ability for a flex item to grow if necessary.
 It accepts a unitless value that serves as a proportion.
 It dictates what amount of the available space inside the
 flex container the item should take up. Negative numbers
@@ -561,7 +561,7 @@ grow g styles =
     else style name (toString g) styles
 
 
-{-else if Set the ability for a flex item to shrink if necessary.
+{-| else if Set the ability for a flex item to shrink if necessary.
 Negative numbers are invalid.
 
     import Css.Flex as Flex
@@ -583,7 +583,7 @@ shrink s styles =
     else style name (toString s) styles
 
 
-{-else if Set the default size of an element before the remaining space is distributed.
+{-| else if Set the default size of an element before the remaining space is distributed.
 
     import Css.Flex as Flex
 
@@ -604,7 +604,7 @@ basis b styles =
     else style name (px b)  styles
 
 
-{-else if Set the default alignment (or the one specified by align-items)
+{-| else if Set the default alignment (or the one specified by align-items)
 to be overridden for individual flex items.
 
     import Css.Flex as Flex

--- a/Example.elm
+++ b/Example.elm
@@ -1,7 +1,7 @@
 module Css.Example where
 
 import Window
-import Signal exposing ((<~), (~), constant, foldp)
+import Signal exposing (map, map2, constant, foldp)
 import Color exposing (Color, rgba, complement)
 import Time exposing (fps)
 
@@ -112,4 +112,4 @@ getTime delta accumulator =
 
 main : Signal Html
 main =
-  view <~ Window.dimensions ~ (foldp getTime 0 (fps 60))
+  map2 view Window.dimensions (foldp getTime 0 (fps 60))


### PR DESCRIPTION
I just started playing with elm and ran into some issues trying to use this library.  
The elm-package.json requires 0.16 so library did not work with 0.15.1 (although maybe would have worked had I changed it in elm-package.json).
I then saw elm 0.16 was released. The install package hadn't been updated yet, but the npm package was so I updated using npm.
I then tried to run this again and ran into some compile errors.  Appears a few things have been removed in 0.16 <~, ~, and if |.  After fixing these and some docstrings I can now run the example.

